### PR TITLE
Remove bounds from histogram

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ impl DrillStats {
 }
 
 fn compute_stats(sub_reports: &[Report]) -> DrillStats {
-  let mut hist = Histogram::<u64>::new_with_bounds(1, 60 * 60 * 1000, 2).unwrap();
+  let mut hist = Histogram::<u64>::new(2).unwrap();
   let mut group_by_status = HashMap::new();
 
   for req in sub_reports {


### PR DESCRIPTION
Histogram without bounds to prevent panics for long response times